### PR TITLE
Add GitHub Actions workflow to release Android APK

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -1,13 +1,5 @@
 # Builds a signed release APK and attaches it to GitHub Releases.
-#
-# Required repository secrets:
-#   ANDROID_KEYSTORE_BASE64  - base64-encoded release keystore (.jks)
-#   ANDROID_KEYSTORE_PASSWORD
-#   ANDROID_KEY_ALIAS
-#   ANDROID_KEY_PASSWORD
-#
-# Generate the base64 value with:
-#   base64 -w 0 release.keystore
+# See RELEASE.md for signing setup, secret generation, and release steps.
 
 name: Release Android APK
 

--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -1,0 +1,120 @@
+# Builds a signed release APK and attaches it to GitHub Releases.
+#
+# Required repository secrets:
+#   ANDROID_KEYSTORE_BASE64  - base64-encoded release keystore (.jks)
+#   ANDROID_KEYSTORE_PASSWORD
+#   ANDROID_KEY_ALIAS
+#   ANDROID_KEY_PASSWORD
+#
+# Generate the base64 value with:
+#   base64 -w 0 release.keystore
+
+name: Release Android APK
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Git tag to attach the APK to (leave empty to only upload a workflow artifact)"
+        required: false
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v3
+
+      - name: Install dependencies and sync Capacitor
+        run: |
+          npm ci
+          npm run cap_build
+
+      - name: Decode signing keystore
+        env:
+          ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+        run: |
+          if [ -z "$ANDROID_KEYSTORE_BASE64" ]; then
+            echo "::error::ANDROID_KEYSTORE_BASE64 secret is not configured"
+            exit 1
+          fi
+          echo "$ANDROID_KEYSTORE_BASE64" | base64 -d > android/app/release.keystore
+
+      - name: Build release APK
+        working-directory: android
+        env:
+          ANDROID_KEYSTORE_FILE: release.keystore
+          ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+          ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+        run: ./gradlew assembleRelease --no-daemon
+
+      - name: Prepare APK artifact
+        id: apk
+        run: |
+          VERSION=$(grep 'versionName' android/app/build.gradle | head -1 | sed -E 's/.*"([^"]+)".*/\1/')
+          APK_DIR="android/app/build/outputs/apk/release"
+          if [ -f "$APK_DIR/app-release.apk" ]; then
+            SOURCE_APK="$APK_DIR/app-release.apk"
+          elif [ -f "$APK_DIR/app-release-unsigned.apk" ]; then
+            echo "::error::Release APK is unsigned. Check signing secrets and Gradle config."
+            exit 1
+          else
+            echo "::error::No release APK found in $APK_DIR"
+            ls -la "$APK_DIR" || true
+            exit 1
+          fi
+
+          if [ "${{ github.event_name }}" = "release" ]; then
+            APK_NAME="xcomps-${{ github.event.release.tag_name }}.apk"
+          elif [ -n "${{ inputs.tag }}" ]; then
+            APK_NAME="xcomps-${{ inputs.tag }}.apk"
+          else
+            APK_NAME="xcomps-${VERSION}.apk"
+          fi
+
+          cp "$SOURCE_APK" "$APK_NAME"
+          echo "name=$APK_NAME" >> "$GITHUB_OUTPUT"
+
+      - name: Upload to GitHub Release
+        if: github.event_name == 'release'
+        uses: softprops/action-gh-release@v2
+        with:
+          files: ${{ steps.apk.outputs.name }}
+
+      - name: Upload to tagged GitHub Release
+        if: github.event_name == 'workflow_dispatch' && inputs.tag != ''
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ inputs.tag }}
+          files: ${{ steps.apk.outputs.name }}
+
+      - name: Upload workflow artifact
+        if: github.event_name == 'workflow_dispatch' && inputs.tag == ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.apk.outputs.name }}
+          path: ${{ steps.apk.outputs.name }}
+          retention-days: 30

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ The files are overwritten each time you download a new one.
 
 You can download the `.apk` file from the [**Releases**](https://github.com/DanielDe8/xcomps/releases) tab.
 
+For maintainers: see [RELEASE.md](./RELEASE.md) for Android APK signing, GitHub Actions setup, and release instructions.
+
 **Warning**: this app may not work with older versions of XCSoar, because they don't store their data in the `Android/media` folder.<br>
 It is recommended to use the latest version of XCSoar, available at [https://xcsoar.org/download](https://xcsoar.org/download)
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,141 @@
+# Releasing XComps
+
+This document explains how Android release APKs are built, how to configure signing for GitHub Actions, and how to cut a release.
+
+## How releases work
+
+The [Release Android APK](.github/workflows/android-release.yml) workflow builds a signed release APK and makes it available in two ways:
+
+1. **Automatic** — when a GitHub Release is published, the workflow attaches `xcomps-<tag>.apk` to that release.
+2. **Manual** — run **Actions → Release Android APK → Run workflow** to rebuild an APK on demand:
+   - Leave **tag** empty to download the APK from workflow artifacts.
+   - Provide a **tag** to attach the APK to an existing GitHub Release.
+
+The workflow runs:
+
+```bash
+npm ci
+npm run cap_build
+cd android && ./gradlew assembleRelease
+```
+
+## One-time setup: signing secrets
+
+The workflow signs release builds using four GitHub repository secrets. All four values come from a single Android release keystore (`.jks` file).
+
+Configure them under **Settings → Secrets and variables → Actions**:
+
+| Secret | Description |
+|--------|-------------|
+| `ANDROID_KEYSTORE_BASE64` | Base64-encoded release keystore |
+| `ANDROID_KEYSTORE_PASSWORD` | Keystore password |
+| `ANDROID_KEY_ALIAS` | Key alias inside the keystore |
+| `ANDROID_KEY_PASSWORD` | Password for that key |
+
+### Reuse an existing keystore
+
+If you already sign release APKs locally, **reuse the same `.jks` file**. Do not create a new keystore if you have published APKs before — Android treats a different signing key as a different app, so users would not be able to upgrade in place.
+
+### Create a new keystore
+
+If this is your first release keystore, generate one with the JDK `keytool` (Java 21 matches this project):
+
+```bash
+keytool -genkeypair -v \
+  -keystore release.keystore \
+  -alias xcomps-release \
+  -keyalg RSA \
+  -keysize 2048 \
+  -validity 10000
+```
+
+`keytool` will prompt for:
+
+- **Keystore password** → `ANDROID_KEYSTORE_PASSWORD`
+- **Key password** → `ANDROID_KEY_PASSWORD` (can be the same as the keystore password)
+- Name, organization, etc. (metadata only; not stored as secrets)
+
+The alias you choose (for example `xcomps-release`) becomes `ANDROID_KEY_ALIAS`.
+
+Back up the keystore and passwords in secure offline storage. Losing the keystore means you cannot publish updates with the same app signing identity.
+
+### Encode the keystore for GitHub
+
+GitHub secrets are text, so the binary `.jks` file must be base64-encoded.
+
+**Linux:**
+
+```bash
+base64 -w 0 release.keystore
+```
+
+**macOS:**
+
+```bash
+base64 -i release.keystore | tr -d '\n'
+```
+
+Copy the entire single-line output into `ANDROID_KEYSTORE_BASE64`.
+
+### Verify the keystore (optional)
+
+```bash
+keytool -list -v -keystore release.keystore
+```
+
+Confirm the alias matches `ANDROID_KEY_ALIAS` before adding secrets to GitHub.
+
+### Add secrets in GitHub
+
+Create a **New repository secret** for each value. Paste values exactly as used when creating the keystore — no surrounding quotes.
+
+During the workflow:
+
+1. `ANDROID_KEYSTORE_BASE64` is decoded to `android/app/release.keystore`
+2. Gradle reads the other three secrets via environment variables
+3. The build produces a signed `app-release.apk`
+
+If any secret is missing or incorrect, the workflow fails at signing or reports an unsigned APK error.
+
+## Local signing (optional)
+
+For local release builds without CI secrets:
+
+1. Place your keystore at `android/app/release.keystore`
+2. Create `android/keystore.properties`:
+
+```properties
+storeFile=release.keystore
+storePassword=your-keystore-password
+keyAlias=xcomps-release
+keyPassword=your-key-password
+```
+
+Keep both files out of git. `.jks` files are already gitignored; consider adding `keystore.properties` to `.gitignore` as well.
+
+Then build locally:
+
+```bash
+npm ci
+npm run cap_build
+cd android && ./gradlew assembleRelease
+```
+
+The signed APK is at `android/app/build/outputs/apk/release/app-release.apk`.
+
+## Cutting a release
+
+1. Bump the app version in `android/app/build.gradle`:
+   - `versionCode` — integer, must increase for each Play Store / upgrade-compatible release
+   - `versionName` — human-readable version shown to users (for example `1.2.2`)
+2. Commit and push the version bump to `main`
+3. Create and publish a GitHub Release with a matching tag (for example `v1.2.2`)
+4. The workflow builds the APK and attaches it to the release automatically
+
+To rebuild an APK without creating a new release, use the manual workflow trigger from the Actions tab.
+
+## Security notes
+
+- Treat the keystore like a password.
+- GitHub Actions secrets are encrypted and not shown in logs, but anyone with repository admin access can rotate them.
+- If you change the keystore or passwords, update all four secrets together.

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -1,5 +1,14 @@
 apply plugin: 'com.android.application'
 
+def keystorePropertiesFile = rootProject.file("keystore.properties")
+def keystoreProperties = new Properties()
+if (keystorePropertiesFile.exists()) {
+    keystoreProperties.load(new FileInputStream(keystorePropertiesFile))
+}
+
+def releaseKeystorePath = System.getenv("ANDROID_KEYSTORE_FILE")
+    ?: (keystoreProperties['storeFile'] ?: null)
+
 android {
     namespace "io.github.danielde8.xcomps"
     compileSdk rootProject.ext.compileSdkVersion
@@ -16,10 +25,23 @@ android {
             ignoreAssetsPattern '!.svn:!.git:!.ds_store:!*.scc:.*:!CVS:!thumbs.db:!picasa.ini:!*~'
         }
     }
+    signingConfigs {
+        release {
+            if (releaseKeystorePath) {
+                storeFile file(releaseKeystorePath)
+                storePassword System.getenv("ANDROID_KEYSTORE_PASSWORD") ?: keystoreProperties['storePassword']
+                keyAlias System.getenv("ANDROID_KEY_ALIAS") ?: keystoreProperties['keyAlias']
+                keyPassword System.getenv("ANDROID_KEY_PASSWORD") ?: keystoreProperties['keyPassword']
+            }
+        }
+    }
     buildTypes {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            if (releaseKeystorePath) {
+                signingConfig signingConfigs.release
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

Adds automated Android APK builds via GitHub Actions:

- **On release publish**: builds a signed release APK and attaches it to the GitHub Release as `xcomps-<tag>.apk`
- **Manual trigger** (`workflow_dispatch`): rebuild an APK on demand
  - Leave the tag input empty to download the APK from workflow artifacts
  - Provide a tag to attach the APK to an existing GitHub Release

## Changes

- **`.github/workflows/android-release.yml`**: new workflow using Node 22, JDK 21, and the Android SDK
- **`android/app/build.gradle`**: signing config driven by environment variables (CI) or an optional `android/keystore.properties` file (local releases)
- **`RELEASE.md`**: human-readable guide for signing setup, GitHub secrets, local builds, and cutting releases
- **`README.md`**: link to `RELEASE.md` for maintainers

## Documentation

See **[RELEASE.md](./RELEASE.md)** for:

- How to create or reuse a release keystore
- Generating and configuring the four required GitHub Actions secrets
- Optional local signing with `keystore.properties`
- Step-by-step release process (version bump → tag → publish)